### PR TITLE
Add start of Shifter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ Finding Docker images that can work with Blue Waters can be a bit tricky given
 > This requirement is tricky to check automatically because it depends on the version of `glibc` and --enable-kernel flag used at the time `glibc` is compiled.
 > If `glibc` provided by the operating system in the image does not support the version of Linux kernel installed on Blue Waters, consider using a different base image.
 
-From a NCSA help ticket, it was revealed that distributions with **`glibc` `v2.23` or older can be made compatible** with the Linux kernel on Blue Waters (`v3.0.101`), whereas `glibc` `v2.24` or newer **can not**.
+From a NCSA [help ticket](https://jira.ncsa.illinois.edu/browse/BWAPPS-6807), it was revealed that distributions with **`glibc` `v2.23` or older can be made compatible** with the Linux kernel on Blue Waters (`v3.0.101`), whereas `glibc` `v2.24` or newer **can not**.
 So before you try to use a Docker image on Blue Waters check it locally.
+
+---
 
 **Examples:**
 
@@ -108,6 +110,8 @@ FATAL: kernel too old
 Application 96757362 exit codes: 127
 Application 96757362 resources: utime ~0s, stime ~1s, Rss ~22900, inblocks ~40955, outblocks ~38774
 ```
+
+---
 
 ### Running a shifter job with GPUs
 
@@ -152,3 +156,13 @@ Copyright (c) 2005-2017 NVIDIA Corporation
 Built on Fri_Nov__3_21:07:56_CDT_2017
 Cuda compilation tools, release 9.1, V9.1.85
 ```
+
+Note that given that Blue Waters has CUDA 9 installed, and CUDA 10 will not be installed given that Blue Waters is entering end-of-life operations, modern machine learning frameworks like JAX, PyTorch (`v1.X`), and TensorFlow (`v2.X`) can not use the GPUs.
+
+Blue Waters does have the [Blue Waters Python software stack (`bwpy`)](https://bluewaters.ncsa.illinois.edu/python), which can be loaded with
+
+```
+module load bwpy/<version you want here> # example bwpy/2.0.4
+```
+
+which includes PyTorch and TensorFlow, but quite old releases (`torch` `v0.X` and `tensorflow` `v1.X`) that are compatible with CUDA v9 only.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Written by Roland McGrath and Ulrich Drepper.
 but the `centos:7` image CAN be used
 
 ```
+$ shifterimg pull centos:7
 $ docker run --rm centos:7 /bin/bash -c "ldd --version"
 ldd (GNU libc) 2.17
 Copyright (C) 2012 Free Software Foundation, Inc.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,32 @@ qsub: waiting for job 12345689.bw to start
 ```
 
 and when it returns (which can take some time) the user will be on a MOM node.
+Once the job starts, load the `shifter` module
+
+```
+module load shifter
+```
+
+to start using the `shifter` and `shifterimg` commands.
+
+```
+aprun -b -N 1 -cc none -- shifter --image=python:3.6.8 -- /bin/bash
+```
+
+It seems that getting the correct Docker base images can be tricky given
+
+> when you prepare a Docker image for your application, make sure to use a base image that provides `glibc` that supports the version of Linux kernel installed on Blue Waters, which is version `3.0.101`.
+> This requirement is tricky to check automatically because it depends on the version of `glibc` and --enable-kernel flag used at the time `glibc` is compiled.
+> If `glibc` provided by the operating system in the image does not support the version of Linux kernel installed on Blue Waters, consider using a different base image.
+
+and it is seen that the official Python Docker images are not compliant
+
+```
+$ shifterimg pull python:3.8
+$ aprun -b -N 1 -cc none -- shifter --image=python:3.8 --entrypoint=/bin/bash
+mount: warning: ufs seems to be mounted read-only.
+mount: warning: dsl/opt seems to be mounted read-only.
+FATAL: kernel too old
+Application 96757362 exit codes: 127
+Application 96757362 resources: utime ~0s, stime ~1s, Rss ~22900, inblocks ~40955, outblocks ~38774
+```

--- a/README.md
+++ b/README.md
@@ -35,8 +35,17 @@ Note: A [Machine Oriented Mini-server](https://linux.die.net/man/8/pbs_mom) (MOM
 
 **Example: Running the `pyhf:latest` Docker image**
 
-From the Blue Waters login node start an interactive job on a single node with 32 processes per node (ppn) on an XE node for a maximum of 1 hour
+From the Blue Waters login node start an interactive Shifter job on a single node with 32 processes per node (ppn) on an XE node for a maximum of 1 hour
 
 ```
-qsub -I -l nodes=1:ppn=32:xe -l walltime=01:00:00
+qsub -I -l gres=shifter -l nodes=1:ppn=32:xe -l walltime=01:00:00
 ```
+
+The job will then be queued up
+
+```
+INFO: Job submitted to account: abcd
+qsub: waiting for job 12345689.bw to start
+```
+
+and when it returns (which can take some time) the user will be on a MOM node.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Examples of running basic jobs on NCSA's Blue Waters
 
 ## Running a Job with Shifter
 
-Most of this will follow the [NCSA Blue Waters docuementation on Shifter](https://bluewaters.ncsa.illinois.edu/shifter), but it will addiitonally give some further information and asides to get new users up to speed.
+Most of this will follow the [NCSA Blue Waters documentation on Shifter](https://bluewaters.ncsa.illinois.edu/shifter), but it will additionally give some further information and asides to get new users up to speed.
 
 > On Blue Waters, Shifter is provided as a module called `shifter`.
 > Unlike other modules, it can only be loaded on a [MOM node](https://bluewaters.ncsa.illinois.edu/interactive-jobs) in a Shifter job, which is a job that requests `shifter` generic resource.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ Examples of running basic jobs on NCSA's Blue Waters
 ## Running a Job with Shifter
 
 Most of this will follow the [NCSA Blue Waters docuementation on Shifter](https://bluewaters.ncsa.illinois.edu/shifter), but it will addiitonally give some further information and asides to get new users up to speed.
+
+> On Blue Waters, Shifter is provided as a module called `shifter`.
+> Unlike other modules, it can only be loaded on a [MOM node](https://bluewaters.ncsa.illinois.edu/interactive-jobs) in a Shifter job, which is a job that requests `shifter` generic resource.
+
+Note: A [Machine Oriented Mini-server](https://linux.die.net/man/8/pbs_mom) (MOM) node is a shared service resource that manages job execution, and on Blue Waters is accessed through starting an [interactive session](https://bluewaters.ncsa.illinois.edu/interactive-jobs).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# NCSA-Blue-Waters-Examples
+# NCSA Blue Waters Examples
+
 Examples of running basic jobs on NCSA's Blue Waters
+
+## Running a Job with Shifter
+
+Most of this will follow the [NCSA Blue Waters docuementation on Shifter](https://bluewaters.ncsa.illinois.edu/shifter), but it will addiitonally give some further information and asides to get new users up to speed.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 Examples of running basic jobs on NCSA's Blue Waters
 
+## Login Node Splash Screen
+
+```
+   ___  __           _      __     __
+  / _ )/ /_ _____   | | /| / /__ _/ /____ ___  ___
+ / _  / / // / -_)  | |/ |/ / _ `/ __/ -_) __)(_-<
+/____/_/\_,_/\__/   |__/|__/\_,_/\__/\__/_/  /___/
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Batch and Scheduler configuration.
+  Queues:  normal (default), high, debug, noalloc
+  Features:  "xe" (default), "xk", "x" (xe or xk non-specific)
+             "xehimem" (128GB mem), "xkhimem" (64GB mem)
+  30 min default wall time, 7 day maximum
+  -lnodes=X:ppn=Y syntax supported.
+
+All SSH traffic on this system is monitored.
+
+Questions?  Mail help+bw@ncsa.illinois.edu to create a support ticket.
+For known issues:  https://bluewaters.ncsa.illinois.edu/known-issues
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
 ## Running a Job with Shifter
 
 Most of this will follow the [NCSA Blue Waters documentation on Shifter](https://bluewaters.ncsa.illinois.edu/shifter), but it will additionally give some further information and asides to get new users up to speed.
@@ -10,3 +32,11 @@ Most of this will follow the [NCSA Blue Waters documentation on Shifter](https:/
 > Unlike other modules, it can only be loaded on a [MOM node](https://bluewaters.ncsa.illinois.edu/interactive-jobs) in a Shifter job, which is a job that requests `shifter` generic resource.
 
 Note: A [Machine Oriented Mini-server](https://linux.die.net/man/8/pbs_mom) (MOM) node is a shared service resource that manages job execution, and on Blue Waters is accessed through starting an [interactive session](https://bluewaters.ncsa.illinois.edu/interactive-jobs).
+
+**Example: Running the `pyhf:latest` Docker image**
+
+From the Blue Waters login node start an interactive job on a single node with 32 processes per node (ppn) on an XE node for a maximum of 1 hour
+
+```
+qsub -I -l nodes=1:ppn=32:xe -l walltime=01:00:00
+```

--- a/aprun-help.md
+++ b/aprun-help.md
@@ -1,0 +1,85 @@
+# `aprun` Help
+
+```
+$ aprun --help
+Usage: aprun [global_options] [command_options] cmd1
+          [: [command_options] cmd2 [: ...] ]
+          [--help] [--version]
+
+--help         Print this help information and exit
+--version      Print version information
+:              Separate binaries for MPMD mode
+               (Multiple Program, Multiple Data)
+
+Global Options:
+-b, --bypass-app-transfer
+    Bypass application transfer to compute node
+-B, --batch-args
+    Get values from Batch reservation for -n, -N, -d, and -m
+-C, --reconnect
+    Reconnect fanout control tree around failed nodes
+-D, --debug level
+    Debug level bitmask (0-7)
+-e, --environment-override env
+    Set an environment variable on the compute nodes
+    Must use format VARNAME=value
+    Set multiple env variables using multiple -e args
+-m, --memory-per-pe size
+    Per PE memory limit in megabytes
+    (default node memory/number of processors)
+    K|M|G suffix supported (16 == 16M == 16 megabytes)
+    Add an 'h' suffix to request per PE huge page memory
+    Add an 's' to the 'h' suffix to make the per PE huge page
+    memory size strict (required)
+-P, --pipes pipes
+    Write[,read] pipes (not applicable for general use)
+-p, --protection-domain pdi
+    Protection domain identifier
+-q, --quiet
+    Quiet mode; suppress aprun non-fatal messages
+-R, --relaunch max_shrink
+    Relaunch application; max_shrink is zero or more maximum
+    PEs to shrink for a relaunch
+-T, --sync-output
+    Use synchronous TTY
+-t, --cpu-time-limit sec
+    Per PE CPU time limit in seconds (default unlimited)
+
+Command Options:
+-a, --architecture arch
+    Architecture type (only XT currently supported)
+--cc, --cpu-binding cpu_list
+    CPU binding list or keyword
+    ([cpu#[,cpu# | cpu1-cpu2] | x]...] | keyword)
+--cp, --cpu-binding-file file
+    CPU binding placement filename
+-d, --cpus-per-pe depth
+    Number of CPUs allocated per PE (number of threads)
+-E, --exclude-node-list node_list
+    List of nodes to exclude from placement
+--exclude-node-list-file node_list_file
+    File with a list of nodes to exclude from placement
+-F, --access-mode flag
+    Exclusive or share node resources flag
+-j, --cpus-per-cu CPUs
+    CPUs to use per Compute Unit (CU)
+-L, --node-list node_list
+    Manual placement list (node[,node | node1-node2]...)
+-l, --node-list-file node_list_file
+    File with manual placement list
+-N, --pes-per-node pes
+    PEs per node
+-n, --pes width
+    Number of PEs requested
+-r, --specialized-cpus CPUs
+    Restrict this many CPUs per node to specialization
+-S, --pes-per-numa-node pes
+    PEs per NUMA node
+--sl, --numa-node-list numa_node_list
+    List of NUMA nodes to use
+    (numa_node[,numa_node | numa_node1-numa_node2]...)
+--sn, --numa-nodes-per-node numa_nodes
+    Maximum number of NUMA nodes used on compute node
+--ss, --strict-memory-containment
+    Strict memory containment per NUMA node
+```


### PR DESCRIPTION
Add walkthrough of how to gain access to Blue Waters nodes that allow for Shifter access.

```
* Add notes on how to gain access to Blue Waters MOM nodes that support Shifter
   - Give example of running Docker image as a Shifter container
   - Note that Blue Waters supports CUDA 9 and so can't use for GPU tests for pyhf
* Add output of `aprun --help`
```